### PR TITLE
WikipediaApi::edit Convert `bot` param to boolean

### DIFF
--- a/wikipedia_api.classes.php
+++ b/wikipedia_api.classes.php
@@ -483,8 +483,11 @@ class WikipediaApi
             'token' => $this->gettoken($page),
             'summary' => $summary,
             ($minor ? 'minor' : 'notminor') => '1',
-            ($bot ? 'bot' : 'notbot') => '1',
         );
+
+        if ($bot) {
+            $params['bot'] = '1';
+        }
 
         if ($wpStarttime !== null) {
             $params['starttimestamp'] = $wpStarttime;


### PR DESCRIPTION
Per https://www.mediawiki.org/wiki/API:Edit `bot` is a boolean,
where the parameter existing with any value means `true` and
an omitted value means `false`.

Thus convert the current `bot` vs `notbot` params to optionally
setting `bot` only.

Fixes #6