### PR TITLE
WikipediaApi::revisions - Remove rvtoken param

### DIFF
--- a/action_functions.php
+++ b/action_functions.php
@@ -121,7 +121,7 @@ class Action
 
     public static function doRevert($change)
     {
-        $rev = Api::$a->revisions($change['title'], 5, 'older', false, null, true, true);
+        $rev = Api::$a->revisions($change['title'], 5, 'older', false, null, true);
         $revid = 0;
         $rbtok = $rev[0]['rollbacktoken'];
         $revdata = false;

--- a/wikipedia_api.classes.php
+++ b/wikipedia_api.classes.php
@@ -671,7 +671,6 @@ class WikipediaApi
      * @param $content Whether to return actual revision content, true or false.  (Default false)
      * @param $revid Revision ID to start at.  (Default null)
      * @param $wait Whether or not to wait a few seconds for the specific revision to become available.  (Default true)
-     * @param $getrbtok Whether or not to retrieve a rollback token for the revision.  (Default false)
      * @param $dieonerror Whether or not to kill the process with an error if an error occurs.  (Default false)
      * @param $redirects Whether or not to follow redirects.  (Default false)
      *
@@ -684,7 +683,6 @@ class WikipediaApi
         $content = false,
         $revid = null,
         $wait = true,
-        $getrbtok = false,
         $dieonerror = true,
         $redirects = false
     ) {
@@ -695,7 +693,7 @@ class WikipediaApi
             urlencode($page) . '&rvlimit=' . urlencode($count) . '&rvprop=timestamp|ids|user|comment' .
             (($content) ? '|content' : '') . '&format=php&meta=userinfo&rvdir=' . urlencode($dir) .
             (($revid !== null) ? '&rvstartid=' . urlencode($revid) : '') .
-            (($getrbtok == true) ? '&rvtoken=rollback' : '') . (($redirects == true) ? '&redirects' : '')
+            (($redirects == true) ? '&redirects' : '')
         );
         $x = unserialize($x);
 
@@ -734,7 +732,7 @@ class WikipediaApi
                 if ($wait == true) {
                     sleep(1);
 
-                    return $this->revisions($page, $count, $dir, $content, $revid, false, $getrbtok, $dieonerror);
+                    return $this->revisions($page, $count, $dir, $content, $revid, false, $dieonerror);
                 } else {
                     if ($dieonerror == true) {
                         die('Revision error.' . "\n");

--- a/wikipedia_index.classes.php
+++ b/wikipedia_index.classes.php
@@ -294,7 +294,7 @@ class WikipediaIndex
         if (($token == null) or (!$token)) {
             $wpapi = new WikipediaApi();
             $wpapi->apiurl = str_replace('index.php', 'api.php', $this->indexurl);
-            $token = $wpapi->revisions($title, 1, 'older', false, null, true, true);
+            $token = $wpapi->revisions($title, 1, 'older', false, null, true);
             if ($token[0]['user'] == $user) {
                 $token = $token[0]['rollbacktoken'];
             } else {

--- a/wikipedia_query.classes.php
+++ b/wikipedia_query.classes.php
@@ -50,7 +50,7 @@ class WikipediaQuery
     public function getpage($page)
     {
         $this->checkurl();
-        $ret = $this->api->revisions($page, 1, 'older', true, null, true, false, false, false);
+        $ret = $this->api->revisions($page, 1, 'older', true, null, true, false, false);
 
         if (is_array($ret) && count($ret) > 0 && array_key_exists('*', $ret[0])) {
             return $ret[0]['*'];
@@ -77,7 +77,7 @@ class WikipediaQuery
     public function getpageid($page)
     {
         $this->checkurl();
-        $ret = $this->api->revisions($page, 1, 'older', false, null, true, false, false, false);
+        $ret = $this->api->revisions($page, 1, 'older', false, null, true, false, false);
 
         return $ret['pageid'];
     }


### PR DESCRIPTION
Per https://www.mediawiki.org/wiki/API:Revisions `rvtoken` was
deprecated in v1.24.

Remove support for specifying the flag which causes the `rvtoken`
parameter to be included.

Fixes #5