### PR TITLE
Use bot password for API

### DIFF
--- a/misc_functions.php
+++ b/misc_functions.php
@@ -49,7 +49,7 @@ function doInit()
 {
     global $logger;
     if (Config::$pass == null) {
-        Config::$pass = trim(file_get_contents(getenv('HOME') . '/.cluebotng.password.only'));
+        Config::$pass = trim(file_get_contents(getenv('HOME') . '/.cluebotng.bot.password'));
     }
     Api::init();
     Api::$a->login(Config::$user, Config::$pass);


### PR DESCRIPTION
Per https://www.mediawiki.org/wiki/API:Login `login` is only supported
for bot passwords, main account logins are now deprecated.

Fixes #4