### PR TITLE
Wikipedia::revisions - specify `rvslots`

### DIFF
--- a/wikipedia_api.classes.php
+++ b/wikipedia_api.classes.php
@@ -691,7 +691,7 @@ class WikipediaApi
         global $logger;
 
         $x = $this->http->get(
-            $this->apiurl . '?action=query&rawcontinue=1&prop=revisions&titles=' .
+            $this->apiurl . '?action=query&rawcontinue=1&prop=revisions&rvslots=main&titles=' .
             urlencode($page) . '&rvlimit=' . urlencode($count) . '&rvprop=timestamp|ids|user|comment' .
             (($content) ? '|content' : '') . '&format=php&meta=userinfo&rvdir=' . urlencode($dir) .
             (($revid !== null) ? '&rvstartid=' . urlencode($revid) : '') .

--- a/wikipedia_index.classes.php
+++ b/wikipedia_index.classes.php
@@ -69,8 +69,8 @@ class WikipediaIndex
         if ($rv == null) {
             $rv = $wpapi->revisions($page, 1, 'older', true);
         }
-        if (!$rv[0]['*']) {
-            $rv[0]['*'] = $wpq->getpage($page);
+        if (!$rv[0]['slots']['main']['*']) {
+            $rv[0]['slots']['main']['*'] = $wpq->getpage($page);
         }
 
         //Fake the edit form.
@@ -90,19 +90,19 @@ class WikipediaIndex
         $html .= "<input type='hidden' value=\"{$token}\" name=\"wpEditToken\" />\n";
         $html .= '<input name="wpAutoSummary" type="hidden" value="' . md5('') . '" />' . "\n";
 
-        if (preg_match('/' . preg_quote('{{nobots}}', '/') . '/iS', $rv[0]['*'])) {
+        if (preg_match('/' . preg_quote('{{nobots}}', '/') . '/iS', $rv[0]['slots']['main']['*'])) {
             return false;
         }        /* Honor the bots flags */
-        if (preg_match('/' . preg_quote('{{bots|allow=none}}', '/') . '/iS', $rv[0]['*'])) {
+        if (preg_match('/' . preg_quote('{{bots|allow=none}}', '/') . '/iS', $rv[0]['slots']['main']['*'])) {
             return false;
         }
-        if (preg_match('/' . preg_quote('{{bots|deny=all}}', '/') . '/iS', $rv[0]['*'])) {
+        if (preg_match('/' . preg_quote('{{bots|deny=all}}', '/') . '/iS', $rv[0]['slots']['main']['*'])) {
             return false;
         }
         if (
             preg_match(
                 '/' . preg_quote('{{bots|deny=', '/') . '(.*)' . preg_quote('}}', '/') . '/iS',
-                $rv[0]['*'],
+                $rv[0]['slots']['main']['*'],
                 $m
             )
         ) {

--- a/wikipedia_query.classes.php
+++ b/wikipedia_query.classes.php
@@ -52,8 +52,8 @@ class WikipediaQuery
         $this->checkurl();
         $ret = $this->api->revisions($page, 1, 'older', true, null, true, false, false, false);
 
-        if (is_array($ret) && count($ret) > 0 && array_key_exists('*', $ret[0])) {
-            return $ret[0]['*'];
+        if (is_array($ret) && count($ret) > 0 && array_key_exists('*', $ret[0]['slots']['main'])) {
+            return $ret[0]['slots']['main']['*'];
         }
     }
 


### PR DESCRIPTION
Per https://www.mediawiki.org/wiki/API:Revisions `rvslots` being omitted
will cause data to be returned in a backwards-compatible format, however
is deprecated.

Previously when `content` was requested the response would be structured
similar to
```
{
  "query": {
    "pages": {
      "xxx": {
        "revisions": [
          {
            "*": "Page content"
          }
        ]
      }
    }
  }
}
```

With the slot specified, the content is re-structured similar to
```
{
  "query": {
    "pages": {
      "xxx": {
        "revisions": [
          {
            "slots": {
              "main": {
                "*": "Page content"
              }
            }
          }
        ]
      }
    }
  }
}
```

Thus also update the consumers to look at the new structure.

Fixes #7