### PR TITLE
processEdit - early abort for whitelist

### DIFF
--- a/process_functions.php
+++ b/process_functions.php
@@ -54,6 +54,11 @@ class Process
                 return;
             }
         }
+        if (Action::isWhitelisted($change['user'])) {
+            $logger->addInfo("User " . $change['user'] . " is whitelisted");
+            Feed::bail($change, 'Whitelisted', null);
+            return;
+        }
         $change = parseFeedData($change);
         $change['justtitle'] = $change['title'];
         if (array_key_exists('namespace', $change) && $change['namespace'] != 'Main:') {
@@ -81,11 +86,6 @@ class Process
             return;
         }
 
-        if (Action::isWhitelisted($change['user'])) {
-            $logger->addInfo("User " . $change['user'] . " is whitelisted");
-            Feed::bail($change, 'Whitelisted', $s);
-            return;
-        }
         $reason = 'ANN scored at ' . $s;
         $heuristic = '';
         $log = null;


### PR DESCRIPTION
Currently we do all the processing for whitelisted users and only skip
reverting right at the end.

To save a lot of work (mainly database connections), abort early if the
change user is whitelisted.

This does change the output to IRC slightly:
1. There will be no ANN score associated with the skip
2. User whitelisted will be shown regardless if the edit would have been
   reverted or not (previously would mostly have been 'below threashold')
