### PR TITLE
HttpFeed - store last event id

### DIFF
--- a/globals.php
+++ b/globals.php
@@ -28,7 +28,6 @@ class Globals
     public static $tfa;
     public static $aoptin;
     public static $cb_mysql;
-    public static $cb_redis;
     public static $run;
     public static $wl = [];
     public static $optin;

--- a/http_feed_functions.php
+++ b/http_feed_functions.php
@@ -31,6 +31,11 @@ class HttpFeed
     {
         global $logger;
 
+        self::$lastEventId = KeyValueStore::getLastHttpEventId();
+        if (self::$lastEventId !== null) {
+            $logger->info("Using last event id: " . self::$lastEventId);
+        }
+
         $recentAttempts = 0;
         for (;;) {
             $recentAttempts++;
@@ -79,6 +84,9 @@ class HttpFeed
                 self::process($event);
             }
 
+            if (self::$lastEventId !== null) {
+                KeyValueStore::saveLastHttpEventId(self::$lastEventId);
+            }
             refreshDataTick();
         } while ($running > 0);
 

--- a/redis_functions.php
+++ b/redis_functions.php
@@ -23,17 +23,19 @@ namespace CluebotNG;
 
 class KeyValueStore
 {
+    private static $client = null;
+
     public static function checkConnection()
     {
         global $logger;
         try {
-            if (!Globals::$cb_redis || !Globals::$cb_redis->ping()) {
+            if (self::$client === null || !self::$client->ping()) {
                 $redis = new \Redis();
                 $redis->pconnect(Config::$cb_redis_host, Config::$cb_redis_port, 1);
                 $redis->auth(Config::$cb_redis_pass);
                 $redis->select(Config::$cb_redis_db);
 
-                Globals::$cb_redis = $redis;
+                self::$client = $redis;
             }
         } catch (\RedisException $e) {
             $logger->warning("Redis connection failed: " . $e->getMessage());
@@ -48,18 +50,18 @@ class KeyValueStore
     public static function getLastRevertTime($page_title, $user)
     {
         self::checkConnection();
-        if (Globals::$cb_redis === null) {
+        if (self::$client === null) {
             return null;
         }
-        return Globals::$cb_redis->get(self::getKey($page_title, $user));
+        return self::$client->get(self::getKey($page_title, $user));
     }
 
     public static function saveRevertTime($page_title, $user)
     {
         self::checkConnection();
-        if (Globals::$cb_redis === null) {
+        if (self::$client === null) {
             return false;
         }
-        return Globals::$cb_redis->set(self::getKey($page_title, $user), time(), (24 * 60 * 60));
+        return self::$client->set(self::getKey($page_title, $user), time(), (24 * 60 * 60));
     }
 }

--- a/redis_functions.php
+++ b/redis_functions.php
@@ -64,4 +64,22 @@ class KeyValueStore
         }
         return self::$client->set(self::getKey($page_title, $user), time(), (24 * 60 * 60));
     }
+
+    public static function getLastHttpEventId()
+    {
+        self::checkConnection();
+        if (self::$client === null) {
+            return null;
+        }
+        return self::$client->get('cbng:http_feed_last_id') ?? null;
+    }
+
+    public static function saveLastHttpEventId($id)
+    {
+        self::checkConnection();
+        if (self::$client === null) {
+            return false;
+        }
+        return self::$client->set('cbng:http_feed_last_id', $id, (10 * 60));
+    }
 }

--- a/redis_functions.php
+++ b/redis_functions.php
@@ -29,7 +29,7 @@ class KeyValueStore
         try {
             if (!Globals::$cb_redis || !Globals::$cb_redis->ping()) {
                 $redis = new \Redis();
-                $redis->pconnect(Config::$cb_redis_host, Config::$cb_redis_port, 2);
+                $redis->pconnect(Config::$cb_redis_host, Config::$cb_redis_port, 1);
                 $redis->auth(Config::$cb_redis_pass);
                 $redis->select(Config::$cb_redis_db);
 
@@ -42,7 +42,7 @@ class KeyValueStore
 
     public static function getKey($page_title, $user)
     {
-        return hash('sha256', $page_title . ':' . $user);
+        return 'cbng:last_reverted:' . hash('sha256', $page_title . ':' . $user);
     }
 
     public static function getLastRevertTime($page_title, $user)


### PR DESCRIPTION
Keep the last event id in Redis with a short TTL.

This will prevent the bot from skipping edits during restarts,
without causing a huge processing backlog if there is an exended outage.