### PR TITLE
Process - re-seed children

### DIFF
--- a/process_functions.php
+++ b/process_functions.php
@@ -95,6 +95,7 @@ class Process
             }
             // Child
             $logger->debug("Fork started");
+            mt_srand();
             Metrics::reset();
         }
         $change = parseFeedData($change);


### PR DESCRIPTION
array_rand uses mt_rand, ensure it is actaully ‘random’ in child forks.

Currently we are hitting the same key in all the forks as the seed is
shared from the parent.