### PR TITLE
MetricServer - ensure local redis connection

### DIFF
--- a/metric_server_functions.php
+++ b/metric_server_functions.php
@@ -73,6 +73,7 @@ class MetricServer
         }
 
         // Child process
+        Metrics::reset();
         $requestHandler = new class () implements RequestHandler {
             public function handleRequest(Request $request): Response
             {


### PR DESCRIPTION
Currently we inherit the parent into the fork,
reset the metrics instance so we get a clean connection.