### PR TITLE
Metrics - fix argument order

### DIFF
--- a/metric_functions.php
+++ b/metric_functions.php
@@ -224,7 +224,7 @@ class Metrics
                 if ($definition['type'] === 'counter') {
                     self::registry()
                         ->getOrRegisterCounter('cbng', $metric_name, $definition['help'], $definition['labels'])
-                        ->incBy([], 0);
+                        ->incBy(0, []);
                 } elseif ($definition['type'] === 'gauge') {
                     self::registry()
                         ->getOrRegisterGauge('cbng', $metric_name, $definition['help'], $definition['labels'])


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #87 
- <kbd>&nbsp;5&nbsp;</kbd> #86 
- <kbd>&nbsp;4&nbsp;</kbd> #85 
- <kbd>&nbsp;3&nbsp;</kbd> #84 
- <kbd>&nbsp;2&nbsp;</kbd> #83 
- <kbd>&nbsp;1&nbsp;</kbd> #82 👈 
<!-- GitButler Footer Boundary Bottom -->

