### PR TITLE
Increase logging level

### DIFF
--- a/action_functions.php
+++ b/action_functions.php
@@ -37,12 +37,12 @@ class Action
         if (!Config::$dry) {
             if ($warning_level >= 4) {
                 /* Report them if they have been warned 4 times. */
-                $logger->info('Reporting ' . $change['user'] . ' to AIV', ['revision_id' => $change['revid']]);
+                $logger->notice('Reporting ' . $change['user'] . ' to AIV', ['revision_id' => $change['revid']]);
                 Metrics::increment('bot_aiv_reports_total');
                 self::aiv($change, $report);
             } else {
                 /* Warn them if they haven't been warned 4 times. */
-                $logger->info(
+                $logger->notice(
                     'Warning ' . $change['user'] . ' with level ' . $warning_level,
                     ['revision_id' => $change['revid']]
                 );
@@ -84,7 +84,6 @@ class Action
 
     private static function aiv($change, $report)
     {
-        global $logger;
         $aivdata = Api::$q->getpage('Wikipedia:Administrator_intervention_against_vandalism/TB2');
         if (!preg_match('/' . preg_quote($change['user'], '/') . '/i', $aivdata)) {
             Api::$a->edit(
@@ -103,7 +102,6 @@ class Action
 
     private static function warn($change, $report, $content, $warning)
     {
-        global $logger;
         $ret = Api::$a->edit(
             'User talk:' . $change['user'],
             $content . "\n\n"
@@ -158,7 +156,6 @@ class Action
 
     public static function shouldRevert($change)
     {
-        global $logger;
         $reason = 'Default revert';
         if (preg_match('/(assisted|manual)/iS', Config::$status)) {
             echo 'Revert [y/N]? ';

--- a/metric_functions.php
+++ b/metric_functions.php
@@ -224,7 +224,7 @@ class Metrics
                 if ($definition['type'] === 'counter') {
                     self::registry()
                         ->getOrRegisterCounter('cbng', $metric_name, $definition['help'], $definition['labels'])
-                        ->incBy([], 0);
+                        ->incBy(0, []);
                 } elseif ($definition['type'] === 'gauge') {
                     self::registry()
                         ->getOrRegisterGauge('cbng', $metric_name, $definition['help'], $definition['labels'])

--- a/mysql_functions.php
+++ b/mysql_functions.php
@@ -124,10 +124,10 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=30 FOR ' .
+            'SET STATEMENT max_statement_time=60 FOR ' .
             'SELECT `rev_timestamp`, `actor_name` FROM `page`' .
             ' JOIN `revision` ON `rev_page` = `page_id`' .
-            ' JOIN `actor` ON `actor_id` = `rev_actor`' .
+            ' JOIN `actor_revision` ON `actor_id` = `rev_actor`' .
             ' WHERE `page_namespace` = "' .
             mysqli_real_escape_string($mw_mysql, $nsid) .
             '" AND `page_title` = "' .
@@ -157,7 +157,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=30 FOR ' .
+            'SET STATEMENT max_statement_time=60 FOR ' .
             'SELECT COUNT(*) as count FROM `page`' .
             ' JOIN `revision` ON `rev_page` = `page_id`' .
             ' WHERE `page_namespace` = "' .
@@ -190,7 +190,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=30 FOR ' .
+            'SET STATEMENT max_statement_time=60 FOR ' .
             'SELECT COUNT(*) as count FROM `page`' .
             ' JOIN `revision` ON `rev_page` = `page_id`' .
             ' JOIN `comment` ON `rev_comment_id` = `comment_id`' .
@@ -232,9 +232,9 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
         try {
             $res = mysqli_query(
                 $mw_mysql,
-                'SET STATEMENT max_statement_time=30 FOR ' .
+                'SET STATEMENT max_statement_time=60 FOR ' .
                 'SELECT COUNT(*) AS `user_editcount` FROM `revision_userindex` ' .
-                ' JOIN `actor` ON `actor_id` = `rev_actor`' .
+                ' JOIN `actor_revision` ON `actor_id` = `rev_actor`' .
                 ' WHERE `actor_name` = "' .
                 mysqli_real_escape_string($mw_mysql, $user) . '"'
             );
@@ -261,7 +261,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
         try {
             $res = mysqli_query(
                 $mw_mysql,
-                'SET STATEMENT max_statement_time=30 FOR ' .
+                'SET STATEMENT max_statement_time=60 FOR ' .
                 'SELECT `user_registration` FROM `user` WHERE `user_name` = "' .
                 mysqli_real_escape_string($mw_mysql, $user) . '"'
             );
@@ -289,9 +289,9 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
             try {
                 $res = mysqli_query(
                     $mw_mysql,
-                    'SET STATEMENT max_statement_time=30 FOR ' .
+                    'SET STATEMENT max_statement_time=60 FOR ' .
                     'SELECT `rev_timestamp` FROM `revision_userindex` ' .
-                    ' JOIN `actor` ON `actor_id` = `rev_actor`' .
+                    ' JOIN `actor_revision` ON `actor_id` = `rev_actor`' .
                     ' WHERE `actor_name` = "' .
                     mysqli_real_escape_string($mw_mysql, $user) . '" ORDER BY `rev_timestamp` LIMIT 0,1'
                 );
@@ -328,7 +328,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
         try {
             $res = mysqli_query(
                 $mw_mysql,
-                'SET STATEMENT max_statement_time=30 FOR ' .
+                'SET STATEMENT max_statement_time=60 FOR ' .
                 'SELECT `user_editcount` FROM `user` WHERE `user_name` =  "' .
                 mysqli_real_escape_string($mw_mysql, $user) . '"'
             );
@@ -356,7 +356,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=30 FOR ' .
+            'SET STATEMENT max_statement_time=60 FOR ' .
             'SELECT COUNT(*) as count FROM `page`' .
             ' JOIN `revision` ON `rev_page` = `page_id`' .
             ' JOIN `comment` ON `rev_comment_id` = `comment_id`' .
@@ -388,9 +388,9 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=30 FOR ' .
+            'SET STATEMENT max_statement_time=60 FOR ' .
             'SELECT count(distinct rev_page) AS count FROM' .
-            ' `revision_userindex` JOIN `actor` ON `actor_id` = `rev_actor`' .
+            ' `revision_userindex` JOIN `actor_revision` ON `actor_id` = `rev_actor`' .
             " WHERE `actor_name` = '" . mysqli_real_escape_string($mw_mysql, $userPage) . "'"
         );
 

--- a/process_functions.php
+++ b/process_functions.php
@@ -159,7 +159,7 @@ class Process
         list($shouldRevert, $revertReason) = Action::shouldRevert($change);
         Metrics::increment('bot_revert_decisions_total', [$shouldRevert ? 'yes' : 'no', $revertReason]);
         if ($shouldRevert) {
-            $logger->info('Reverting: ' . $revertReason, ['revision_id' => $change['revid'], 'score' => $score]);
+            $logger->notice('Reverting: ' . $revertReason, ['revision_id' => $change['revid'], 'score' => $score]);
             Metrics::increment('bot_reverts_attempted_total');
             $rbret = Action::doRevert($change);
             if ($rbret !== false) {
@@ -170,7 +170,7 @@ class Process
             } else {
                 $rv2 = Api::$a->revisions($change['title'], 1);
                 if (!empty($rv2) && $change['user'] != $rv2[0]['user']) {
-                    $logger->info(
+                    $logger->notice(
                         'Revert Beaten By: ' . $rv2[0]['user'],
                         ['revision_id' => $change['revid'], 'score' => $score]
                     );
@@ -180,7 +180,7 @@ class Process
                 }
             }
         } else {
-            $logger->info('Not Reverting: ' . $revertReason, ['revision_id' => $change['revid'], 'score' => $score]);
+            $logger->notice('Not Reverting: ' . $revertReason, ['revision_id' => $change['revid'], 'score' => $score]);
             Relay::publishEdit($change, $score, false, $revertReason);
         }
     }


### PR DESCRIPTION
For the key events put these at NOTICE so they are easy to get out of the logs.

INFO is quite noisy, so it’s useful to be able to exclude when making changes.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #87 
- <kbd>&nbsp;5&nbsp;</kbd> #86 
- <kbd>&nbsp;4&nbsp;</kbd> #85 
- <kbd>&nbsp;3&nbsp;</kbd> #84 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #83 
- <kbd>&nbsp;1&nbsp;</kbd> #82 
<!-- GitButler Footer Boundary Bottom -->

