### PR TITLE
health-check - make less sensitive

### DIFF
--- a/health_check.php
+++ b/health_check.php
@@ -50,14 +50,14 @@ if (count($usercontribs) != 1) {
 $last_contrib_timestamp = $usercontribs[0]['timestamp'];
 Metrics::set('bot_last_contribution_seconds', (float)strtotime($last_contrib_timestamp));
 
- /* If we edited recently, then all good */
-if (strtotime($last_contrib_timestamp) > (time() - 3600)) {
+ /* If we edited within the last 3 hours, then all good */
+if (strtotime($last_contrib_timestamp) > (time() - 10800)) {
     $logger->info('Last contribution was beyond threshold (' . $last_contrib_timestamp . ')');
     exit(0);
 }
 
- /* If we have been running for less than 30min, then all good (back off) */
-if ($start_time > (time() - 1800)) {
+ /* If we have been running for less than 1 hour, then all good (back off) */
+if ($start_time > (time() - 3600)) {
     $logger->info('Uptime less than 30min (' . $start_time . ')');
     exit(0);
 }


### PR DESCRIPTION
Now we have improved the error handling and re-connection logic, there
are less issues.

Increase the thresholds so we don’t restart the bot during quiet times
(no vandalism), which happens occasionally.

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #87 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #86 
- <kbd>&nbsp;4&nbsp;</kbd> #85 
- <kbd>&nbsp;3&nbsp;</kbd> #84 
- <kbd>&nbsp;2&nbsp;</kbd> #83 
- <kbd>&nbsp;1&nbsp;</kbd> #82 
<!-- GitButler Footer Boundary Bottom -->

