### PR TITLE
getCbData - increase query timeouts

### DIFF
--- a/mysql_functions.php
+++ b/mysql_functions.php
@@ -124,7 +124,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=60 FOR ' .
+            'SET STATEMENT max_statement_time=120 FOR ' .
             'SELECT `rev_timestamp`, `actor_name` FROM `page`' .
             ' JOIN `revision` ON `rev_page` = `page_id`' .
             ' JOIN `actor_revision` ON `actor_id` = `rev_actor`' .
@@ -157,7 +157,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=60 FOR ' .
+            'SET STATEMENT max_statement_time=120 FOR ' .
             'SELECT COUNT(*) as count FROM `page`' .
             ' JOIN `revision` ON `rev_page` = `page_id`' .
             ' WHERE `page_namespace` = "' .
@@ -190,7 +190,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=60 FOR ' .
+            'SET STATEMENT max_statement_time=120 FOR ' .
             'SELECT COUNT(*) as count FROM `page`' .
             ' JOIN `revision` ON `rev_page` = `page_id`' .
             ' JOIN `comment` ON `rev_comment_id` = `comment_id`' .
@@ -232,7 +232,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
         try {
             $res = mysqli_query(
                 $mw_mysql,
-                'SET STATEMENT max_statement_time=60 FOR ' .
+                'SET STATEMENT max_statement_time=120 FOR ' .
                 'SELECT COUNT(*) AS `user_editcount` FROM `revision_userindex` ' .
                 ' JOIN `actor_revision` ON `actor_id` = `rev_actor`' .
                 ' WHERE `actor_name` = "' .
@@ -261,7 +261,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
         try {
             $res = mysqli_query(
                 $mw_mysql,
-                'SET STATEMENT max_statement_time=60 FOR ' .
+                'SET STATEMENT max_statement_time=120 FOR ' .
                 'SELECT `user_registration` FROM `user` WHERE `user_name` = "' .
                 mysqli_real_escape_string($mw_mysql, $user) . '"'
             );
@@ -289,7 +289,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
             try {
                 $res = mysqli_query(
                     $mw_mysql,
-                    'SET STATEMENT max_statement_time=60 FOR ' .
+                    'SET STATEMENT max_statement_time=120 FOR ' .
                     'SELECT `rev_timestamp` FROM `revision_userindex` ' .
                     ' JOIN `actor_revision` ON `actor_id` = `rev_actor`' .
                     ' WHERE `actor_name` = "' .
@@ -328,7 +328,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
         try {
             $res = mysqli_query(
                 $mw_mysql,
-                'SET STATEMENT max_statement_time=60 FOR ' .
+                'SET STATEMENT max_statement_time=120 FOR ' .
                 'SELECT `user_editcount` FROM `user` WHERE `user_name` =  "' .
                 mysqli_real_escape_string($mw_mysql, $user) . '"'
             );
@@ -356,7 +356,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=60 FOR ' .
+            'SET STATEMENT max_statement_time=120 FOR ' .
             'SELECT COUNT(*) as count FROM `page`' .
             ' JOIN `revision` ON `rev_page` = `page_id`' .
             ' JOIN `comment` ON `rev_comment_id` = `comment_id`' .
@@ -388,7 +388,7 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
     try {
         $res = mysqli_query(
             $mw_mysql,
-            'SET STATEMENT max_statement_time=60 FOR ' .
+            'SET STATEMENT max_statement_time=120 FOR ' .
             'SELECT count(distinct rev_page) AS count FROM' .
             ' `revision_userindex` JOIN `actor_revision` ON `actor_id` = `rev_actor`' .
             " WHERE `actor_name` = '" . mysqli_real_escape_string($mw_mysql, $userPage) . "'"


### PR DESCRIPTION
We are currently not hitting connection limits, bump the query timeout
(for large accounts > million edits).

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #90 
- <kbd>&nbsp;1&nbsp;</kbd> #89 👈 
<!-- GitButler Footer Boundary Bottom -->

