### PR TITLE
Add bot whitelist

### DIFF
--- a/action_functions.php
+++ b/action_functions.php
@@ -226,8 +226,13 @@ class Action
         return true;
     }
 
-    public static function isWhitelisted($user)
+    public static function isWhitelistedUser($user)
     {
         return in_array($user, Globals::$wl, true);
+    }
+
+    public static function isWhitelistedBot($user)
+    {
+        return in_array($user, Config::$bot_whitelist, true);
     }
 }

--- a/cluebot-ng.config.php
+++ b/cluebot-ng.config.php
@@ -52,6 +52,8 @@ class Config
     public static $cb_redis_pass = '';
     public static $metrics_enabled = true;
     public static $metrics_port = 9095;
+    // Bots which are spikey in changes and have very large edit counts
+    public static $bot_whitelist = ['InternetArchiveBot', 'AnomieBOT', 'Jevansen'];
 
     public static function init()
     {

--- a/metric_functions.php
+++ b/metric_functions.php
@@ -88,8 +88,13 @@ class Metrics
             []
         );
         self::registerCounter(
-            'bot_edits_whitelisted_total',
+            'bot_edits_whitelisted_user_total',
             'Total edits skipped because the user is whitelisted',
+            []
+        );
+        self::registerCounter(
+            'bot_edits_whitelisted_bot_total',
+            'Total edits skipped because the bot is whitelisted',
             []
         );
         self::registerCounter(

--- a/process_functions.php
+++ b/process_functions.php
@@ -81,6 +81,13 @@ class Process
             return;
         }
 
+        // Ignore whitelisted bots as early as possible - before starting to load any data
+        if (Action::isWhitelistedBot($change['user'])) {
+            $logger->info('Skipping: Bot whitelisted', ['revision_id' => $change['revid'], 'bot' => $change['user']]);
+            Metrics::increment('bot_edits_whitelisted_bot_total');
+            return;
+        }
+
         if (Config::$fork) {
             $pid = pcntl_fork();
             if ($pid == -1) {
@@ -124,9 +131,12 @@ class Process
             return;
         }
 
-        if (Action::isWhitelisted($change['user'])) {
-            $logger->info('Skipping: User whitelisted', ['revision_id' => $change['revid'], 'score' => $score]);
-            Metrics::increment('bot_edits_whitelisted_total');
+        if (Action::isWhitelistedUser($change['user'])) {
+            $logger->info(
+                'Skipping: User whitelisted',
+                ['revision_id' => $change['revid'], 'score' => $score, 'user' => $change['user']]
+            );
+            Metrics::increment('bot_edits_whitelisted_user_total');
             Relay::publishEdit($change, $score, false, 'User whitelisted');
             return;
         }

--- a/relay_functions.php
+++ b/relay_functions.php
@@ -25,21 +25,23 @@ class Relay
 {
     public static function publishEdit($change, $score = null, $reverted = false, $comment = null)
     {
-        self::send(json_encode([
-            'change' => [
-                'namespace' => $change['namespace'],
-                'title' => $change['namespaced_title'],
-                'revision_id' => $change['revid'],
-                'flags' => $change['flags'],
-                'user' => $change['user'],
-                'length' => $change['length'],
-                'comment' => $change['comment'],
-                'url' => $change['url'],
-            ],
-            'score' => $score,
-            'reverted' => $reverted,
-            'comment' => $comment,
-        ]));
+        if ($score !== null || $reverted === true) {
+            self::send(json_encode([
+                'change' => [
+                    'namespace' => $change['namespace'],
+                    'title' => $change['namespaced_title'],
+                    'revision_id' => $change['revid'],
+                    'flags' => $change['flags'],
+                    'user' => $change['user'],
+                    'length' => $change['length'],
+                    'comment' => $change['comment'],
+                    'url' => $change['url'],
+                ],
+                'score' => $score,
+                'reverted' => $reverted,
+                'comment' => $comment,
+            ]));
+        }
     }
 
     public static function publishWarnedUser($username, $level)


### PR DESCRIPTION
There are limited number of accounts which perform bulk edits.

This is challenging for the pipeline as we execute a large number of
forks (with associated db queries), the users also have a large amount
of edits (millions) which cause the queries to be slow.

It is very unlikely the bot type edits are vandalism, so just skip them.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #90 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #89 
<!-- GitButler Footer Boundary Bottom -->

