### PR TITLE
HttpFeed - increase error logging

### DIFF
--- a/http_feed_functions.php
+++ b/http_feed_functions.php
@@ -126,10 +126,10 @@ class HttpFeed
             // CURLE_HTTP2_STREAM - the server will close the connection after 15min.
             // x-ref: https://wikitech.wikimedia.org/wiki/Event_Platform/EventStreams_HTTP_Service
             if ($info['result'] === 92 && $uptime > 720) {
-                $logger->debug($log_message);
+                $logger->debug($log_message, ['curl_result' => $info['result'], 'uptime' => $uptime]);
                 $server_enforced_timeout = true;
             } else {
-                $logger->error($log_message);
+                $logger->error($log_message, ['curl_result' => $info['result'], 'uptime' => $uptime]);
             }
         }
 

--- a/http_feed_functions.php
+++ b/http_feed_functions.php
@@ -85,14 +85,18 @@ class HttpFeed
 
         $ch = curl_init('https://stream.wikimedia.org/v2/stream/mediawiki.recentchange');
         curl_setopt_array($ch, [
-            CURLOPT_HTTPHEADER     => $headers,
-            CURLOPT_WRITEFUNCTION  => [self::class, 'processChunk'],
-            CURLOPT_TIMEOUT        => 0,
-            CURLOPT_CONNECTTIMEOUT => 10,
-            CURLOPT_TCP_KEEPALIVE  => 1,
-            CURLOPT_BUFFERSIZE     => 128,
-            CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_USERAGENT      => 'ClueBot/2.0',
+            CURLOPT_HTTPHEADER      => $headers,
+            CURLOPT_WRITEFUNCTION   => [self::class, 'processChunk'],
+            CURLOPT_HTTP_VERSION    => CURL_HTTP_VERSION_2TLS,
+            CURLOPT_TIMEOUT         => 0,
+            CURLOPT_CONNECTTIMEOUT  => 10,
+            CURLOPT_TCP_KEEPALIVE   => 1,
+            CURLOPT_TCP_KEEPIDLE    => 30,
+            CURLOPT_TCP_KEEPINTVL   => 15,
+            CURLOPT_LOW_SPEED_LIMIT => 1,
+            CURLOPT_LOW_SPEED_TIME  => 90,
+            CURLOPT_FOLLOWLOCATION  => true,
+            CURLOPT_USERAGENT       => 'ClueBot/2.0',
         ]);
 
         $mh = curl_multi_init();

--- a/http_feed_functions.php
+++ b/http_feed_functions.php
@@ -39,10 +39,10 @@ class HttpFeed
         }
 
         $recentAttempts = 0;
-        $server_enforced_timeout = false;
+        $handle_interruption_gracefully = false;
         while (self::$running) {
             $recentAttempts++;
-            [$uptime, $server_enforced_timeout] = self::connect($server_enforced_timeout);
+            [$uptime, $handle_interruption_gracefully] = self::connect($handle_interruption_gracefully);
             if (!self::$running) {
                 break;
             }
@@ -118,25 +118,28 @@ class HttpFeed
         } while ($running > 0 && self::$running);
 
         $uptime = time() - $start_time;
-        $server_enforced_timeout = false;
+        $handle_interruption_gracefully = false;
 
         $info = curl_multi_info_read($mh);
         if ($info !== false && $info['result'] !== CURLE_OK) {
-            $log_message = 'EventStream hit curl error: ' . curl_strerror($info['result']);
             // CURLE_HTTP2_STREAM - the server will close the connection after 15min.
             // x-ref: https://wikitech.wikimedia.org/wiki/Event_Platform/EventStreams_HTTP_Service
-            if ($info['result'] === 92 && $uptime > 720) {
-                $logger->debug($log_message, ['curl_result' => $info['result'], 'uptime' => $uptime]);
-                $server_enforced_timeout = true;
+            //
+            // It appears to happen more often than 15min, so don't gate on time, just re-connect.
+            // As we are tracking the last ID, we shouldn't miss events, just be slower to see them.
+            $log_message = 'EventStream hit curl error: ' . curl_strerror($info['result']);
+            if ($info['result'] === 92) {
+                $logger->debug($log_message, ['uptime' => $uptime]);
+                $handle_interruption_gracefully = true;
             } else {
-                $logger->error($log_message, ['curl_result' => $info['result'], 'uptime' => $uptime]);
+                $logger->error($log_message, ['uptime' => $uptime]);
             }
         }
 
         curl_multi_remove_handle($mh, $ch);
         curl_multi_close($mh);
 
-        return [$uptime, $server_enforced_timeout];
+        return [$uptime, $handle_interruption_gracefully];
     }
 
     private static function processChunk($ch, $chunk)


### PR DESCRIPTION
We are logging CURLE_HTTP2_STREAM events are ERROR level, rather than
DEBUG.

Add the literal curl return code and update, so we have more insight
into the runtime state vs conditional logic.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #95 
- <kbd>&nbsp;4&nbsp;</kbd> #94 
- <kbd>&nbsp;3&nbsp;</kbd> #93 
- <kbd>&nbsp;2&nbsp;</kbd> #92 
- <kbd>&nbsp;1&nbsp;</kbd> #91 👈 
<!-- GitButler Footer Boundary Bottom -->

