### PR TITLE
page metadata - optimise query

### DIFF
--- a/action_functions.php
+++ b/action_functions.php
@@ -37,14 +37,17 @@ class Action
         if (!Config::$dry) {
             if ($warning_level >= 4) {
                 /* Report them if they have been warned 4 times. */
-                $logger->notice('Reporting ' . $change['user'] . ' to AIV', ['revision_id' => $change['revid']]);
+                $logger->notice(
+                    'Reporting user to AIV',
+                    ['revision_id' => $change['revid'], 'user' => $change['user']]
+                );
                 Metrics::increment('bot_aiv_reports_total');
                 self::aiv($change, $report);
             } else {
                 /* Warn them if they haven't been warned 4 times. */
                 $logger->notice(
-                    'Warning ' . $change['user'] . ' with level ' . $warning_level,
-                    ['revision_id' => $change['revid']]
+                    'Adding warning to user talk page',
+                    ['revision_id' => $change['revid'], 'user' => $change['user'], 'level' => $warning_level]
                 );
                 Metrics::increment('bot_warnings_issued_total', [(string)$warning_level]);
                 self::warn($change, $report, $tpcontent, $warning_level);
@@ -121,8 +124,15 @@ class Action
 
     public static function doRevert($change)
     {
+        global $logger;
         $rev = Api::$a->revisions($change['namespaced_title'], 5, 'older', false, null, true);
         if (empty($rev)) {
+            $logger->warning(
+                'Skipping revert due to no previous revisions',
+                ['revision_id' => $change['revid']]
+            );
+            Metrics::increment('bot_reverts_skipped_total', ['reason' => 'missing_revisions']);
+            Relay::publishEdit($change, $score, false, 'Failed to find previous revision');
             return false;
         }
         $revid = 0;
@@ -134,15 +144,31 @@ class Action
             }
         }
         if ($revdata === null) {
+            $logger->warning(
+                'Skipping revert due to missing previous revision by another user',
+                ['revision_id' => $change['revid'], 'candidate_revisions' => count($revdata)],
+            );
+            Metrics::increment('bot_reverts_skipped_total', ['reason' => 'previous_revisions_by_user']);
+            Relay::publishEdit($change, $score, false, 'Prevision revision by same user');
             return false;
         }
-        if (($revdata['user'] == Config::$user) or (in_array($revdata['user'], Config::$friends))) {
+        if ($revdata['user'] == Config::$user) {
+            $logger->notice('Skipping revert of own account', ['revision_id' => $change['revid']]);
+            Metrics::increment('bot_reverts_skipped_total', ['reason' => 'own_account']);
+            Relay::publishEdit($change, $score, false, 'User is self');
+            return false;
+        }
+        if (in_array($revdata['user'], Config::$friends)) {
+            $logger->notice('Skipping revert of a friend', ['revision_id' => $change['revid']]);
+            Metrics::increment('bot_reverts_skipped_total', ['reason' => 'friends_account']);
+            Relay::publishEdit($change, $score, false, 'User is a friend');
             return false;
         }
         if (Config::$dry) {
+            $logger->warning('Faking revert due to configuration', ['revision_id' => $change['revid']]);
             return true;
         }
-        $rbret = Api::$a->rollback(
+        return Api::$a->rollback(
             $change['namespaced_title'],
             $change['user'],
             'Reverting possible vandalism by [[Special:Contribs/' . $change['user'] . '|' . $change['user'] . ']] ' .
@@ -150,8 +176,6 @@ class Action
             '[[WP:CBFP|Report False Positive?]] ' .
             'Thanks, [[WP:CBNG|' . Config::$user . ']]. (' . $change['mysqlid'] . ') (Bot)',
         );
-
-        return $rbret;
     }
 
     public static function shouldRevert($change)

--- a/cbng.php
+++ b/cbng.php
@@ -102,16 +102,20 @@ function parseFeedData($feedData)
         and isset($api['revisions'][1]['timestamp'])
         and isset($api['revisions'][1]['*']))
     ) {
-        $logger->warning("Failed to get revision info", ['revision_id' => $feedData['revid']]);
+        $logger->warning(
+            "Failed to get revision info",
+            ['revision_id' => $feedData['revid'], 'title' => $feedData['namespaced_title']]
+        );
         Metrics::increment('bot_edits_skipped_missing_revision_data_total');
         return null;
     }
 
+    $cutoff_timestamp = $feedData['timestamp'] - (14 * 86400);
     $cb = getCbData(
         $feedData['user'],
         $feedData['namespaceid'],
         $feedData['title'],
-        $feedData['timestamp'] - (14 * 86400)
+        $cutoff_timestamp
     );
     if (
         !(isset($cb['user_edit_count'])
@@ -119,7 +123,16 @@ function parseFeedData($feedData)
         and isset($cb['user_warns'])
         and isset($cb['user_reg_time']))
     ) {
-        $logger->warning("Failed to get user info", ['revision_id' => $feedData['revid']]);
+        $logger->warning(
+            "Failed to get user info",
+            [
+                'revision_id' => $feedData['revid'],
+                'user' => $feedData['user'],
+                'namespace_id' => $feedData['namespaceid'],
+                'title' => $feedData['title'],
+                'cutoff_timestamp' => $cutoff_timestamp,
+            ]
+        );
         Metrics::increment('bot_edits_skipped_missing_cb_data_total');
         return null;
     }
@@ -129,7 +142,16 @@ function parseFeedData($feedData)
         and isset($cb['common']['num_recent_edits'])
         and isset($cb['common']['num_recent_reversions']))
     ) {
-        $logger->warning("Failed to get common info", ['revision_id' => $feedData['revid']]);
+        $logger->warning(
+            "Failed to get common info",
+            [
+                'revision_id' => $feedData['revid'],
+                'user' => $feedData['user'],
+                'namespace_id' => $feedData['namespaceid'],
+                'title' => $feedData['title'],
+                'cutoff_timestamp' => $cutoff_timestamp,
+            ]
+        );
         return null;
     }
 

--- a/metric_functions.php
+++ b/metric_functions.php
@@ -123,6 +123,11 @@ class Metrics
             []
         );
         self::registerCounter(
+            'bot_reverts_skipped_total',
+            'Total reverts skipped',
+            ['reason']
+        );
+        self::registerCounter(
             'bot_mysql_mw_query_failures_total',
             'Total replica MySQL query failures',
             ['query', 'reason']

--- a/mysql_functions.php
+++ b/mysql_functions.php
@@ -125,14 +125,16 @@ function getCbData($user = '', $nsid = '', $title = '', $timestamp = '')
         $res = mysqli_query(
             $mw_mysql,
             'SET STATEMENT max_statement_time=120 FOR ' .
-            'SELECT `rev_timestamp`, `actor_name` FROM `page`' .
-            ' JOIN `revision` ON `rev_page` = `page_id`' .
+            'SELECT `rev_timestamp`, `actor_name` FROM `revision`' .
             ' JOIN `actor_revision` ON `actor_id` = `rev_actor`' .
-            ' WHERE `page_namespace` = "' .
-            mysqli_real_escape_string($mw_mysql, $nsid) .
-            '" AND `page_title` = "' .
-            mysqli_real_escape_string($mw_mysql, $title) .
-            '" ORDER BY `rev_id` LIMIT 1'
+            ' WHERE `rev_id` = (' .
+            '  SELECT MIN(`rev_id`) FROM `revision`' .
+            '  JOIN `page` ON `page_id` = `rev_page`' .
+            '  WHERE' .
+            '  `page_namespace` = "' . mysqli_real_escape_string($mw_mysql, $nsid) . '"' .
+            '  AND ' .
+            '  `page_title` = "' . mysqli_real_escape_string($mw_mysql, $title) . '"' .
+            ')'
         );
         if ($res === false) {
             $logger->warning("page metadata query returned no data for " . $title .

--- a/process_functions.php
+++ b/process_functions.php
@@ -169,7 +169,10 @@ class Process
         list($shouldRevert, $revertReason) = Action::shouldRevert($change);
         Metrics::increment('bot_revert_decisions_total', [$shouldRevert ? 'yes' : 'no', $revertReason]);
         if ($shouldRevert) {
-            $logger->notice('Reverting: ' . $revertReason, ['revision_id' => $change['revid'], 'score' => $score]);
+            $logger->notice(
+                'Reverting: ' . $revertReason,
+                ['revision_id' => $change['revid'], 'score' => $score, 'user' => $change['user']]
+            );
             Metrics::increment('bot_reverts_attempted_total');
             $rbret = Action::doRevert($change);
             if ($rbret !== false) {
@@ -181,8 +184,8 @@ class Process
                 $rv2 = Api::$a->revisions($change['title'], 1);
                 if (!empty($rv2) && $change['user'] != $rv2[0]['user']) {
                     $logger->notice(
-                        'Revert Beaten By: ' . $rv2[0]['user'],
-                        ['revision_id' => $change['revid'], 'score' => $score]
+                        'Revert Beaten',
+                        ['revision_id' => $change['revid'], 'score' => $score, 'beaten_by' => $rv2[0]['user']]
                     );
                     Metrics::increment('bot_reverts_beaten_total');
                     Relay::publishEdit($change, $score, false, 'Beaten by ' . $rv2[0]['user']);
@@ -190,7 +193,10 @@ class Process
                 }
             }
         } else {
-            $logger->notice('Not Reverting: ' . $revertReason, ['revision_id' => $change['revid'], 'score' => $score]);
+            $logger->notice(
+                'Not Reverting: ' . $revertReason,
+                ['revision_id' => $change['revid'], 'score' => $score, 'user' => $change['user']]
+            );
             Relay::publishEdit($change, $score, false, $revertReason);
         }
     }


### PR DESCRIPTION
For large pages (such as List_of_Netflix_original_programming),
the current query is very slow (>1.5min).

While the new query is pretty ugly, it is a lot faster (<1 second).

Logically we are now;
1. Find the smallest revision id for a given page
2. Lookup the timestamp and author of that revision id

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #95 
- <kbd>&nbsp;4&nbsp;</kbd> #94 
- <kbd>&nbsp;3&nbsp;</kbd> #93 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #92 
- <kbd>&nbsp;1&nbsp;</kbd> #91 
<!-- GitButler Footer Boundary Bottom -->

