### PR TITLE
Add logic to constraint number of children

### DIFF
--- a/action_functions.php
+++ b/action_functions.php
@@ -122,7 +122,7 @@ class Action
         );
     }
 
-    public static function doRevert($change)
+    public static function doRevert($change, $score)
     {
         global $logger;
         $rev = Api::$a->revisions($change['namespaced_title'], 5, 'older', false, null, true);

--- a/cluebot-ng.config.php
+++ b/cluebot-ng.config.php
@@ -44,7 +44,7 @@ class Config
     public static $core_port = 3565;
     public static $relay_host = 'irc-relay';
     public static $relay_port = 9334;
-    public static $fork = true;
+    public static $max_forks = 30;
     public static $dry = false;
     public static $cb_redis_host = 'redis';
     public static $cb_redis_port = 6379;
@@ -91,6 +91,10 @@ class Config
 
         if ($port = getenv('CBNG_METRICS_PORT')) {
             self::$metrics_port = (int) $port;
+        }
+
+        if ($max_forks = getenv('CBNG_MAX_FORKS')) {
+            self::$max_forks = (int) $max_forks;
         }
     }
 }

--- a/cluebot-ng.php
+++ b/cluebot-ng.php
@@ -60,6 +60,12 @@ if (Config::$metrics_enabled) {
 }
 HttpFeed::stream();
 
+$logger->info('Waiting for ' . Process::pendingChangesTotal() . ' pending changes');
+while (Process::pendingChangesTotal() > 0) {
+    Process::dispatchPending();
+    usleep(100000);
+}
+
 $logger->info('Waiting for ' . count(Globals::$activeChildren) . ' workers to finish');
 while (!empty(Globals::$activeChildren)) {
     usleep(100000);

--- a/http_feed_functions.php
+++ b/http_feed_functions.php
@@ -119,6 +119,7 @@ class HttpFeed
                 self::$lastCheckpointTime = time();
             }
             refreshDataTick();
+            Process::dispatchPending();
         } while ($running > 0 && self::$running);
 
         $uptime = time() - $start_time;

--- a/process_functions.php
+++ b/process_functions.php
@@ -23,6 +23,13 @@ namespace CluebotNG;
 
 class Process
 {
+    private static $pendingChanges = [];
+
+    public static function pendingChangesTotal()
+    {
+        return count(self::$pendingChanges);
+    }
+
     public static function processEdit($change)
     {
         global $logger;
@@ -88,7 +95,20 @@ class Process
             return;
         }
 
-        if (Config::$fork) {
+        self::$pendingChanges[] = $change;
+        self::dispatchPending();
+    }
+
+    public static function dispatchPending()
+    {
+        global $logger;
+
+        while (
+            !empty(self::$pendingChanges) &&
+            (Config::$max_forks <= 0 || count(Globals::$activeChildren) < Config::$max_forks)
+        ) {
+            $change = array_shift(self::$pendingChanges);
+
             $pid = pcntl_fork();
             if ($pid == -1) {
                 $logger->error("Failed to fork");
@@ -99,20 +119,18 @@ class Process
                 $logger->debug("Created fork with " . $pid);
                 Globals::$activeChildren[$pid] = true;
                 Metrics::set('bot_forks_total', count(Globals::$activeChildren));
-                return;
+                continue;
             }
             // Child
             $logger->debug("Fork started");
             mt_srand();
             Metrics::reset();
-        }
-        $change = parseFeedData($change);
-        if ($change === null) {
-            Metrics::increment('bot_edits_skipped_missing_data_total');
-        } else {
-            self::processEditThread($change);
-        }
-        if (Config::$fork) {
+            $change = parseFeedData($change);
+            if ($change === null) {
+                Metrics::increment('bot_edits_skipped_missing_data_total');
+            } else {
+                self::processEditThread($change);
+            }
             $logger->debug("Fork finished");
             // Avoid propagating shutdown signals from die() which cause curl's connection to get dropped
             posix_kill(posix_getpid(), SIGKILL);

--- a/process_functions.php
+++ b/process_functions.php
@@ -174,7 +174,7 @@ class Process
                 ['revision_id' => $change['revid'], 'score' => $score, 'user' => $change['user']]
             );
             Metrics::increment('bot_reverts_attempted_total');
-            $rbret = Action::doRevert($change);
+            $rbret = Action::doRevert($change, $score);
             if ($rbret !== false) {
                 Metrics::increment('bot_reverts_succeeded_total');
                 Relay::publishEdit($change, $score, true, $revertReason);


### PR DESCRIPTION
Currently we can fork an un-bounded number of children.

Add a simple in-memory queue (array) and limit the number of child
processes.

Note: $fork is now always true - we don’t run without them

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #98 
- <kbd>&nbsp;2&nbsp;</kbd> #97 
- <kbd>&nbsp;1&nbsp;</kbd> #95 👈 
<!-- GitButler Footer Boundary Bottom -->

